### PR TITLE
Add GitHub Actions build script for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  windows:
+    strategy:
+      fail-fast: true
+
+    name: Windows
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        install: >-
+          diffutils
+          git
+          make
+          mingw-w64-ucrt-x86_64-cmake
+          mingw-w64-ucrt-x86_64-make
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-imagemagick
+          mingw-w64-ucrt-x86_64-boost
+          mingw-w64-ucrt-x86_64-libxml2
+          zip
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake .. \
+          -DLIBXML2_INCLUDE_DIR=$MINGW_PREFIX/include/libxml2 \
+          -DImageMagick_COMPILE_OPTIONS=`MagickWand-config --cppflags | sed 's/ /;/g'` \
+          -DImageMagick_LIBRARIES=`MagickWand-config --libs | sed 's/ /;/g'`
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        cmake --build .
+        echo "::endgroup::"
+
+    - name: Package
+      run: |
+        mkdir warp-sabre
+        cp build/*.exe AUTHORS COPYING INSTALL README \
+          /ucrt64/bin/{libgcc_s_seh-1,libwinpthread-1,libintl-8,libxml2-2,libMagickCore-7.Q16HDRI-10,libMagickWand-7.Q16HDRI-10,libstdc++-6,libboost_thread-mt,libiconv-2}.dll \
+          /ucrt64/bin/{liblzma-5,libbz2-1,libfftw3-3,libfontconfig-1,libfreetype-6,liblcms2-2,liblqr-1-0,libltdl-7,libraqm-0,libexpat-1,libbrotlidec,libbrotlicommon}.dll \
+          /ucrt64/bin/{libharfbuzz-0,libglib-2.0-0,libpcre2-8-0,libgraphite2,libpng16-16,zlib1,libfribidi-0}.dll \
+          warp-sabre/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: warp-sabre-windows
+        path: warp-sabre

--- a/src/GenTiles.cpp
+++ b/src/GenTiles.cpp
@@ -37,6 +37,14 @@ using namespace std;
 #define OUT_TILE_WIDTH 256
 #define OUT_TILE_HEIGHT 256
 
+#if defined(_MSC_VER) || defined(_UCRT)
+	#include <direct.h>
+
+	#define MKDIR(x) _mkdir((x))
+#else
+	#define MKDIR(x) mkdir((x), S_IRWXU)
+#endif
+
 char **__g_argv;
 
 struct RescaleParams
@@ -453,29 +461,13 @@ int TileJob::Render()
 	// outImg = tile;
 
 	if (!dirExists(this->outFolder0.c_str()))
-	{
-#ifdef _WIN32
-		mkdir(this->outFolder0.c_str());
-#else
-		mkdir(this->outFolder0.c_str(), S_IRWXU);
-#endif
-	}
+		MKDIR(this->outFolder0.c_str());
+
 	if (!dirExists(this->outFolder1.c_str()))
-	{
-#ifdef _WIN32
-		mkdir(this->outFolder1.c_str());
-#else
-		mkdir(this->outFolder1.c_str(), S_IRWXU);
-#endif
-	}
+		MKDIR(this->outFolder1.c_str());
+
 	if (!dirExists(this->outFolder2.c_str()))
-	{
-#ifdef _WIN32
-		mkdir(this->outFolder2.c_str());
-#else
-		mkdir(this->outFolder2.c_str(), S_IRWXU);
-#endif
-	}
+		MKDIR(this->outFolder2.c_str());
 
 	outImg.Save(this->outFilename.c_str());
 	// temp.syncPixels();

--- a/src/newmat-10/INSTALL
+++ b/src/newmat-10/INSTALL
@@ -1,1 +1,0 @@
-/opt/homebrew/Cellar/automake/1.16.5/share/automake-1.16/INSTALL

--- a/src/newmat-10/depcomp
+++ b/src/newmat-10/depcomp
@@ -1,1 +1,0 @@
-/opt/homebrew/Cellar/automake/1.16.5/share/automake-1.16/depcomp

--- a/src/newmat-10/ltmain.sh
+++ b/src/newmat-10/ltmain.sh
@@ -1,1 +1,0 @@
-/opt/homebrew/Cellar/libtool/2.4.7/share/libtool/build-aux/ltmain.sh

--- a/src/newmat-10/missing
+++ b/src/newmat-10/missing
@@ -1,1 +1,0 @@
-/opt/homebrew/Cellar/automake/1.16.5/share/automake-1.16/missing


### PR DESCRIPTION
This is what I was working on, simplified a bit now since it doesn't need to download and build the dependencies separately!

It bundles everything into a .zip, including all the required DLLs. Ideally I'd do a static build, but doing so with mingw-w64 seems to be non-trivial (at least for ImageMagick). I've often preferred to use `vcpkg` for Windows open source dependency management (coupled with MSVC of course) but it doesn't have ImageMagick, only GraphicsMagick - which might well be fine, I don't know for sure.

I kept my version of the GenTiles.cpp fix in as it felt a bit tidier to me.

The various `newmat-10` removals appear to have been added as symlinks to locations on your own filesystem, which my git got confused about on Windows. They're not used by the build process so I just removed them.